### PR TITLE
Add workflow to automatically download/update helm chart tar

### DIFF
--- a/.github/workflows/update-helm-tar.yml
+++ b/.github/workflows/update-helm-tar.yml
@@ -1,0 +1,9 @@
+name: Update Helm Tarball
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  update-helm-deps-tarballs:
+    uses: metal-toolbox/helm-tar-update/.github/workflows/helm-tar-update.yml@main


### PR DESCRIPTION
This works with Renovate.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
