### PR TITLE
Drop jumpcloud from dex config

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: sigstack
 description: Helm chart for running all of our sigstore goodies (rekor, fulcio, trillian,  
 type: application
 
-version: 0.1.0
+version: 0.2.0
 
 appVersion: "0.1.0"
 

--- a/values.yaml
+++ b/values.yaml
@@ -82,9 +82,3 @@ dex:
   configSecret:
     create: false
     name: sigstack-dex-config
-  envVars:
-  - name: LDAP_BINDPW
-    valueFrom:
-      secretKeyRef:
-        key: ldap-bindpw
-        name: jumpcloud


### PR DESCRIPTION
This will drop the jumpcloud secret from dex as a default.